### PR TITLE
Changed official portspoof website to the legitimate site.

### DIFF
--- a/Tools/Annoyance/Portspoof.md
+++ b/Tools/Annoyance/Portspoof.md
@@ -4,7 +4,7 @@ Portspoof
 Website
 -------
 
-<http://portspoof.org/>
+<https://drk1wi.github.io/portspoof/>
 
 Description
 -----------


### PR DESCRIPTION
http://portspoof.org seems to be a spam site with drop-shipping tips now. drk1wi. https://github.io/portspoof is the official site.